### PR TITLE
Support TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ can be seen in the [hanoverd](https://github.com/sensiblecodeio/hanoverd/) proje
 ```
 
 
+TLS/SSL support
+---------------
+
+To allow (and enforce) encrypted connections, provide the paths to your SSL key and
+certificate:
+
+```
+$ HOOKBOT_KEY=foo hookbot serve --sslkey=/path/to/ssl.key --sslcrt=/path/to/ssl.crt
+```
+
+If the certificate is signed by a certificate authority, the certFile should be the
+concatenation of the server's certificate, any intermediates, and the CA's certificate.
+
 Generating tokens
 -----------------
 

--- a/main.go
+++ b/main.go
@@ -47,6 +47,16 @@ func main() {
 					Value: ":8080",
 					Usage: "address to listen on",
 				},
+				cli.StringFlag{
+					Name:  "sslkey, k",
+					Value: "<unset>",
+					Usage: "path to the SSL secret key",
+				},
+				cli.StringFlag{
+					Name:  "sslcrt, c",
+					Value: "<unset>",
+					Usage: "path to the SSL compound certificate",
+				},
 				cli.StringSliceFlag{
 					Name:  "router",
 					Value: &cli.StringSlice{},
@@ -188,7 +198,16 @@ func ActionServe(c *cli.Context) {
 	})
 
 	log.Println("Listening on", c.String("bind"))
-	err := http.ListenAndServe(c.String("bind"), nil)
+
+	sslkey := c.String("sslkey")
+
+	var err error
+
+	if sslkey == "<unset>" {
+		err = http.ListenAndServe(c.String("bind"), nil)
+	} else {
+		err = http.ListenAndServeTLS(c.String("bind"), c.String("sslcrt"), c.String("sslkey"), nil)
+	}
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Add support for TLS without need for a proxy.

(tiny-ssl-reverse-proxy works well, but complicates things like handling origins other than sameorigin)