### PR TITLE
Allow origins other than "sameorigin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ can be seen in the [hanoverd](https://github.com/sensiblecodeio/hanoverd/) proje
 	}
 ```
 
+Accepted Origins
+----------------
+
+By default, hoobot only accepts requests with no `Origin` header, or where the origin host
+matches the host in the URL.
+
+To accept other origins, use the `--origin` flag, as follows:
+
+```
+$ HOOKBOT_KEY=foo hookbot serve --origin http://localhost:4200 --origin https://hookbot.scraperwiki.com
+```
+
+Note that when the origin flag is used, same-host requests or requests with no `Origin` header
+are no longer accepted.
+
 
 Generating tokens
 -----------------

--- a/main.go
+++ b/main.go
@@ -48,6 +48,11 @@ func main() {
 					Usage: "address to listen on",
 				},
 				cli.StringSliceFlag{
+					Name:  "origin",
+					Value: &cli.StringSlice{},
+					Usage: "list of accepted origins",
+				},
+				cli.StringSliceFlag{
 					Name:  "router",
 					Value: &cli.StringSlice{},
 					Usage: "list of routers to enable",
@@ -172,6 +177,9 @@ func ActionMakeTokens(c *cli.Context) {
 }
 
 func ActionServe(c *cli.Context) {
+
+	hookbot.ConfigureServeHTTP(c.StringSlice("origin"))
+
 	key := c.GlobalString("key")
 	if key == "<unset>" {
 		log.Fatalln("HOOKBOT_KEY not set")
@@ -189,6 +197,7 @@ func ActionServe(c *cli.Context) {
 
 	log.Println("Listening on", c.String("bind"))
 	err := http.ListenAndServe(c.String("bind"), nil)
+
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/hookbot/util.go
+++ b/pkg/hookbot/util.go
@@ -7,9 +7,31 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
+var upgrader websocket.Upgrader
+
+func ConfigureServeHTTP(allowedOrigins []string) {
+
+	if len(allowedOrigins) == 0 {
+		upgrader = websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+		}
+	} else {
+		upgrader = websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+			CheckOrigin: func(r *http.Request) bool {
+				for _, o := range r.Header["Origin"] {
+					for _, ao := range allowedOrigins {
+						if o == ao {
+							return true
+						}
+					}
+				}
+				return false
+			},
+		}
+	}
 }
 
 type WebsocketHandlerFunc func(*websocket.Conn, *http.Request)


### PR DESCRIPTION
Added a command-line option to specify origins which should be accepted.

I'm not very happy with the "architecture" of the solution, and it would be nice to cater for "samehost" and "no-origin" (which are the two cases accepted without the new flag, or without this pull request). But it works, it is useful, and it is as far as I could get with my (very limited) knowedge of go and the time available.