### PR TITLE
Update import for codegangsta/cli to urfave/cli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/sensiblecodeio/hookbot
 go 1.12
 
 require (
-	github.com/codegangsta/cli v1.20.0
 	github.com/gorilla/websocket v1.4.1
+	github.com/urfave/cli v1.20.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
+github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 
 	"github.com/sensiblecodeio/hookbot/pkg/hookbot"
 	"github.com/sensiblecodeio/hookbot/pkg/router/github"

--- a/pkg/hookbot/router.go
+++ b/pkg/hookbot/router.go
@@ -3,7 +3,7 @@ package hookbot
 import (
 	"log"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 type Router interface {

--- a/pkg/router/github/github.go
+++ b/pkg/router/github/github.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 
 	"github.com/sensiblecodeio/hookbot/pkg/hookbot"
 	"github.com/sensiblecodeio/hookbot/pkg/listen"


### PR DESCRIPTION
This package moved locations on GitHub.

Have set the version to v1.20 still as it's known good for hookbot.

The later 1.2x versions have some regression that I don't know
whether it impacts hookbot: urfave/cli#850 and has only recently
been fixed, without a later 1.2x fixed version released yet.