### PR TITLE
Remove redundant `go get -v`

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,10 +19,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Install
-        run: |
-          go get -v .
-
       - name: Run tests
         run: |
           make test


### PR DESCRIPTION
Now covered by the Docker build.