### PR TITLE
Switch to using `X-Hub-Signature-256` for GitHub

### DIFF
--- a/pkg/hookbot/hookbot.go
+++ b/pkg/hookbot/hookbot.go
@@ -377,7 +377,7 @@ func (h *Hookbot) ServePublish(w http.ResponseWriter, r *http.Request) {
 		case "github":
 
 			body, err = json.Marshal(map[string]interface{}{
-				"Signature": r.Header.Get("X-Hub-Signature"),
+				"Signature": r.Header.Get("X-Hub-Signature-256"),
 				"Event":     r.Header.Get("X-GitHub-Event"),
 				"Delivery":  r.Header.Get("X-GitHub-Delivery"),
 				"Payload":   body,

--- a/pkg/router/github/auth.go
+++ b/pkg/router/github/auth.go
@@ -3,6 +3,7 @@ package github
 import (
 	"crypto/hmac"
 	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,12 @@ import (
 
 func Sha1HMAC(key string, payload []byte) string {
 	mac := hmac.New(sha1.New, []byte(key))
+	_, _ = mac.Write(payload)
+	return fmt.Sprintf("%x", mac.Sum(nil))
+}
+
+func Sha256HMAC(key string, payload []byte) string {
+	mac := hmac.New(sha256.New, []byte(key))
 	_, _ = mac.Write(payload)
 	return fmt.Sprintf("%x", mac.Sum(nil))
 }
@@ -39,7 +46,7 @@ func IsValidGithubSignature(secret string, message []byte) bool {
 	}
 
 	expected := m.Signature
-	got := fmt.Sprintf("sha1=%v", Sha1HMAC(secret, m.Payload))
+	got := fmt.Sprintf("sha256=%v", Sha256HMAC(secret, m.Payload))
 
 	log.Printf("Expected = %v got = %v", expected, got)
 


### PR DESCRIPTION
> Make sure you are using the correct header. GitHub recommends that you
> use the `X-Hub-Signature-256` header, which uses the HMAC-SHA256 algorithm.
> The X-Hub-Signature header uses the HMAC-SHA1 algorithm and is only
> included for legacy purposes.